### PR TITLE
Update README instructions on using the dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,13 @@ to know how tha image was built. The repo also has `build` and `start` scripts t
 
 ### Using the Dashboards ###
 
-Once your container is running all you need to do is open your browser pointing to the host/port you just published and
-play with the dashboard at your wish. We hope that you have a lot of fun with this image and that it serves it's
+Once your container is running all you need to do is:
+- open your browser pointing to the host/port you just published
+- login with the default username (admin) and password (admin)
+- configure a new datasource to point at the Graphite metric data (URL - http://localhost:8000) and replace the default Grafana test datasource for your graphs
+- then play with the dashboard at your wish...
+
+We hope that you have a lot of fun with this image and that it serves it's
 purpose of making your life easier. This should give you an idea of how the dashboard looks like when receiving data
 from one of our toy applications:
 


### PR DESCRIPTION
Provide additional instructions to allow users of the image to get started quicker including the default login credentials as well as how to configure the Graphite data source.