### PR TITLE
Refactor Grafana Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,20 @@ If you already have services running on your host that are using any of these po
 ports to whatever you want by changing left side number in the `-p` parameters. Find more details about mapping ports
 in the [Docker documentation](http://docs.docker.io/use/port_redirection/#port-redirection).
 
+### To keep dashboard configuration permanent
+
+Create an empty db file and attach it to the container as volume:
+
+```
+sudo touch /opt/grafana.db
+docker run -d \
+-v /opt/grafana.db:/opt/grafana/data/grafana.db \
+-p 80:80 \
+-p 8125:8125/udp \
+-p 8126:8126 \
+--name kamon-grafana-dashboard \
+kamon/grafana_graphite
+```
 
 ### Building the image yourself ###
 

--- a/README.md
+++ b/README.md
@@ -25,14 +25,21 @@ If you already have services running on your host that are using any of these po
 ports to whatever you want by changing left side number in the `-p` parameters. Find more details about mapping ports
 in the [Docker documentation](http://docs.docker.io/use/port_redirection/#port-redirection).
 
-### To keep dashboard configuration permanent
+### To keep data and dashboard configuration permanent
 
-Create an empty db file and attach it to the container as volume:
+Create an empty db file and a directory in the Docker host
 
 ```
 sudo touch /opt/grafana.db
+sudo mkdir /opt/graphite/storage/whisper
+```
+
+Attach file and directory as volume
+
+```
 docker run -d \
 -v /opt/grafana.db:/opt/grafana/data/grafana.db \
+-v /opt/graphite/storage/whisper:/opt/graphite/storage/whisper \
 -p 80:80 \
 -p 8125:8125/udp \
 -p 8126:8126 \

--- a/README.md
+++ b/README.md
@@ -47,6 +47,96 @@ docker run -d \
 kamon/grafana_graphite
 ```
 
+### How to run Database and WebApp on different container
+
+Create 2 supervisord configuration file for frontend services (nginx, grafana-webapp, graphite-webapp, dashboard-loader, statsd) and backend service (carbon-cache).
+
+**frontend.conf**
+```
+[supervisord]
+nodaemon = true
+environment = GRAPHITE_STORAGE_DIR='/opt/graphite/storage',GRAPHITE_CONF_DIR='/opt/graphite/conf'
+
+[program:nginx]
+command = /usr/sbin/nginx
+stdout_logfile = /var/log/supervisor/%(program_name)s.log
+stderr_logfile = /var/log/supervisor/%(program_name)s.log
+autorestart = true
+
+[program:grafana-webapp]
+;user = www-data
+directory = /opt/grafana/
+command = /opt/grafana/bin/grafana-server
+stdout_logfile = /var/log/supervisor/%(program_name)s.log
+stderr_logfile = /var/log/supervisor/%(program_name)s.log
+autorestart = true
+
+[program:graphite-webapp]
+;user = www-data
+directory = /opt/graphite/webapp
+environment = PYTHONPATH='/opt/graphite/webapp'
+command = /usr/bin/gunicorn_django -b127.0.0.1:8000 -w2 graphite/settings.py
+stdout_logfile = /var/log/supervisor/%(program_name)s.log
+stderr_logfile = /var/log/supervisor/%(program_name)s.log
+autorestart = true
+
+[program:statsd]
+;user = www-data
+command = /usr/bin/node /src/statsd/stats.js /src/statsd/config.js
+stdout_logfile = /var/log/supervisor/%(program_name)s.log
+stderr_logfile = /var/log/supervisor/%(program_name)s.log
+autorestart = true
+
+[program:dashboard-loader]
+;user = www-data
+directory = /src/dashboards
+command = /usr/bin/node /src/dashboard-loader/dashboard-loader.js -w .
+stdout_logfile = /var/log/supervisor/%(program_name)s.log
+stderr_logfile = /var/log/supervisor/%(program_name)s.log
+exitcodes = 0
+autorestart = unexpected
+startretries = 3
+```
+
+**backend.conf**
+```
+[supervisord]
+nodaemon = true
+environment = GRAPHITE_STORAGE_DIR='/opt/graphite/storage',GRAPHITE_CONF_DIR='/opt/graphite/conf'
+
+[program:carbon-cache]
+;user = www-data
+command = /opt/graphite/bin/carbon-cache.py --debug start
+stdout_logfile = /var/log/supervisor/%(program_name)s.log
+stderr_logfile = /var/log/supervisor/%(program_name)s.log
+autorestart = true
+```
+
+Attach each config file into its respective container
+
+**FRONTEND**
+```
+docker run -d \
+-v /opt/graphite/grafana.db:/opt/grafana/data/grafana.db \
+-v /opt/graphite/storage/whisper:/opt/graphite/storage/whisper \
+-v /opt/graphite/frontend.conf:/etc/supervisor/conf.d/supervisord.conf \
+-p 80:80 \
+-p 8125:8125/udp \
+-p 8126:8126 \
+--name grafana-frontend \
+kamon/grafana_graphite
+```
+**BACKEND**
+```
+docker run -d \
+-v /opt/graphite/grafana.db:/opt/grafana/data/grafana.db \
+-v /opt/graphite/storage/whisper:/opt/graphite/storage/whisper \
+-v /opt/graphite/backend.conf:/etc/supervisor/conf.d/supervisord.conf \
+-p 2003:2003 \
+--name grafana-backend \
+kamon/grafana_graphite
+```
+
 ### Building the image yourself ###
 
 The Dockerfile and supporting configuration files are available in our [Github repository](https://github.com/kamon-io/docker-grafana-graphite).


### PR DESCRIPTION
# What's this PR do?
Refactoring grafana container for production environment

# Where should the reviewer start?
This a README update on how to run DB and WebApp on separate container.
https://github.com/sekka1/docker-grafana-graphite/tree/refactor#how-to-run-database-and-webapp-on-different-container

# How should this be manually tested?
- Add graphite as data source

In dashboard go to data sources and click add new 
Name: graphite-source
Type: Graphite
Url: http://localhost:8000
Access: proxy

- Run a bunch of these with different values each time to send metrics to carbon

```
echo "carbon.agents.graphite-test.metricsReceived 28198 `date +%s`" | nc localhost 2003
echo "carbon.agents.graphite-test.creates 8 `date +%s`" | nc localhost 2003
```

- Create new dashboard

From Home click button "+ New"
Add panel > Graph
Click panel title bar > Edit
In metric tab change data source from grafana to graphite-source
Select the following metric: carbon.agents.graphite-test.metricsReceived
You can add another row for the other metric: carbon.agents.graphite-test.creates
Click back to dashboard