### PR TITLE
Pytz is a missing package for graphite.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN     apt-get -y install python-django-tagging python-simplejson python-memcac
 
 RUN     pip install Twisted==11.1.0
 RUN     pip install Django==1.5
+RUN     pip install pytz
 RUN     npm install ini chokidar
 
 # Checkout the stable branches of Graphite, Carbon and Whisper and install from there


### PR DESCRIPTION
The bug is fixed in the graphite project, maybe it will be better to just
update it.

Source: https://github.com/graphite-project/graphite-web/issues/1019