### PR TITLE
Use Ubuntu 14.04 instead of pinning to 14.04.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM     ubuntu:14.04.1
+FROM     ubuntu:14.04
 
 # ---------------- #
 #   Installation   #


### PR DESCRIPTION
This way we always have the latest and greatest Ubuntu 14.04 LTS