### PR TITLE
Bind on both IPv4 and IPv6 for all services.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN     apt-get -y update
 RUN     apt-get -y install python-django-tagging python-simplejson python-memcache python-ldap python-cairo python-pysqlite2 python-support \
                            python-pip gunicorn supervisor nginx-light nodejs git wget curl openjdk-7-jre build-essential python-dev
 
-RUN     pip install Twisted==11.1.0
+RUN     pip install Twisted==13.2.0
 RUN     pip install Django==1.5
 RUN     pip install pytz
 RUN     npm install ini chokidar

--- a/graphite/carbon.conf
+++ b/graphite/carbon.conf
@@ -27,13 +27,13 @@ MAX_UPDATES_PER_SECOND = 1000
 # the files quickly but at the risk of slowing I/O down considerably for a while.
 MAX_CREATES_PER_MINUTE = inf
 
-LINE_RECEIVER_INTERFACE = 0.0.0.0
+LINE_RECEIVER_INTERFACE = ::
 LINE_RECEIVER_PORT = 2003
 
-PICKLE_RECEIVER_INTERFACE = 0.0.0.0
+PICKLE_RECEIVER_INTERFACE = ::
 PICKLE_RECEIVER_PORT = 2004
 
-CACHE_QUERY_INTERFACE = 0.0.0.0
+CACHE_QUERY_INTERFACE = ::
 CACHE_QUERY_PORT = 7002
 
 # By default, carbon-cache will log every whisper update and cache hit. This can be excessive and
@@ -71,10 +71,10 @@ LOG_LISTENER_CONNECTIONS = False
 # interfaces and ports for the listeners.
 
 [relay]
-LINE_RECEIVER_INTERFACE = 0.0.0.0
+LINE_RECEIVER_INTERFACE = ::
 LINE_RECEIVER_PORT = 2003
 
-PICKLE_RECEIVER_INTERFACE = 0.0.0.0
+PICKLE_RECEIVER_INTERFACE = ::
 PICKLE_RECEIVER_PORT = 2004
 
 CACHE_SERVERS = server1, server2, server3

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -27,10 +27,10 @@ http {
   gzip_disable "msie6";
 
   server {
-    listen 80 default_server;
+    listen [::]:80 default_server ipv6only=off;
     server_name _;
     location / {
-        proxy_pass                 http://127.0.0.1:3000/;
+        proxy_pass                 http://localhost:3000/;
         proxy_set_header           X-Real-IP   $remote_addr;
         proxy_set_header           X-Forwarded-For  $proxy_add_x_forwarded_for;
         proxy_set_header           X-Forwarded-Proto  $scheme;
@@ -51,7 +51,7 @@ http {
         proxy_temp_file_write_size 64k;
     }
     location /graphite/ {
-        proxy_pass                 http://127.0.0.1:8000/;
+        proxy_pass                 http://localhost:8000/;
         proxy_set_header           X-Real-IP   $remote_addr;
         proxy_set_header           X-Forwarded-For  $proxy_add_x_forwarded_for;
         proxy_set_header           X-Forwarded-Proto  $scheme;
@@ -78,13 +78,13 @@ http {
   }
 
   server {
-    listen 81 default_server;
+    listen [::]:81 default_server ipv6only=off;
     server_name _;
 
     open_log_file_cache max=1000 inactive=20s min_uses=2 valid=1m;
 
     location / {
-        proxy_pass                 http://127.0.0.1:8000;
+        proxy_pass                 http://localhost:8000;
         proxy_set_header           X-Real-IP   $remote_addr;
         proxy_set_header           X-Forwarded-For  $proxy_add_x_forwarded_for;
         proxy_set_header           X-Forwarded-Proto  $scheme;

--- a/statsd/config.js
+++ b/statsd/config.js
@@ -1,11 +1,14 @@
 {
   port: 8125,
+  address: "::",
+
   mgmt_port: 8126,
+  mgmt_address: "::",
 
   percentThreshold: [ 50, 75, 90, 95, 98, 99, 99.9, 99.99, 99.999],
 
   graphitePort: 2003,
-  graphiteHost: "127.0.0.1",
+  graphiteHost: "localhost",
   flushInterval: 10000,
 
   backends: ['./backends/graphite'],


### PR DESCRIPTION
This allows users to access Nginx and Graphite via IPv6 as well
enabling them to use this container in a IPv6-only environment.

IPv4 traffic hasn't changed, it only adds IPv6 as an addition.