### PR TITLE
Expose Graphite data source port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,6 +97,9 @@ EXPOSE  8125/udp
 # StatsD Management port
 EXPOSE  8126
 
+# Graphite web port
+EXPOSE 8000
+
 
 
 # -------- #


### PR DESCRIPTION
In some cases it is required to have access to Graphite web API and Carbon.

For example, I am writing test that data comes to `statsd` and Grafana is a too awkward way to do that.