### PR TITLE
Documentation contains persistence instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,11 @@ docker run \
    --publish=8125:8125/udp \
    --publish=8126:8126 \
    --name kamon-grafana-dashboard \
-   --volume=$(pwd)\data\whisper:/opt/graphite/storage/whisper \
-   --volume=$(pwd)\data\elasticsearch:/var/lib/elasticsearch \
-   --volume=$(pwd)\data\grafana:/opt/grafana/data \
-   --volume=$(pwd)\log\graphite:/opt/graphite/storage/log \
-   --volume=$(pwd)\log\elasticsearch:/var/log/elasticsearch \
+   --volume=$(pwd)/data/whisper:/opt/graphite/storage/whisper \
+   --volume=$(pwd)/data/elasticsearch:/var/lib/elasticsearch \
+   --volume=$(pwd)/data/grafana:/opt/grafana/data \
+   --volume=$(pwd)/log/graphite:/opt/graphite/storage/log \
+   --volume=$(pwd)/log/elasticsearch:/var/log/elasticsearch \
    kamon/grafana_graphite
 ```
 

--- a/README.md
+++ b/README.md
@@ -69,11 +69,11 @@ docker run \
    --publish=8125:8125/udp \
    --publish=8126:8126 \
    --name kamon-grafana-dashboard \
-   --volume=$(pwd)]data\whisper:/opt/graphite/storage/whisper \
-   --volume=$(pwd)]data\elasticsearch:/var/lib/elasticsearch \
-   --volume=$(pwd)]data\grafana:/opt/grafana/data \
-   --volume=$(pwd)]log\graphite:/opt/graphite/storage/log \
-   --volume=$(pwd)]log\elasticsearch:/var/log/elasticsearch \
+   --volume=$(pwd)\data\whisper:/opt/graphite/storage/whisper \
+   --volume=$(pwd)\data\elasticsearch:/var/lib/elasticsearch \
+   --volume=$(pwd)\data\grafana:/opt/grafana/data \
+   --volume=$(pwd)\log\graphite:/opt/graphite/storage/log \
+   --volume=$(pwd)\log\elasticsearch:/var/log/elasticsearch \
    kamon/grafana_graphite
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ for using this image:
 
 ### Using the Docker Index ###
 
-This image is published under [Kamon's repository on the Docker Index](https://index.docker.io/u/kamon/) and all you
+This image is published under [Kamon's repository on the Docker Hub](https://hub.docker.com/u/kamon/) and all you
 need as a prerequisite is having Docker installed on your machine. The container exposes the following ports:
 
 - `80`: the Grafana web interface.
@@ -19,11 +19,18 @@ need as a prerequisite is having Docker installed on your machine. The container
 To start a container with this image you just need to run the following command:
 
 ```bash
-docker run -d -p 80:80 -p 81:81 -p 8125:8125/udp -p 8126:8126 --name kamon-grafana-dashboard kamon/grafana_graphite
+docker run \
+  --detach \
+   --publish=80:80 \
+   --publish=81:81 \
+   --publish=8125:8125/udp \
+   --publish=8126:8126 \
+   --name kamon-grafana-dashboard \
+   kamon/grafana_graphite
 ```
 
 If you already have services running on your host that are using any of these ports, you may wish to map the container
-ports to whatever you want by changing left side number in the `-p` parameters. You can omit ports you do not plan to use. Find more details about mapping ports in the [Docker documentation](http://docs.docker.io/use/port_redirection/#port-redirection).
+ports to whatever you want by changing left side number in the `--publish` parameters. You can omit ports you do not plan to use. Find more details about mapping ports in the Docker documentation on [Binding container ports to the host](https://docs.docker.com/engine/userguide/networking/default_network/binding/) and [Legacy container links](https://docs.docker.com/engine/userguide/networking/default_network/dockerlinks/).
 
 
 ### Building the image yourself ###
@@ -40,6 +47,37 @@ Once your container is running all you need to do is:
 - login with the default username (admin) and password (admin)
 - configure a new datasource to point at the Graphite metric data (URL - http://localhost:8000) and replace the default Grafana test datasource for your graphs
 - then play with the dashboard at your wish...
+
+### Making your data last ###
+
+There are several ways of using Docker volumes to persist the settings and databases of the docker-grafana-graphite container. Here is an example script that will create directories on your host and mount them into the Docker container, allowing graphite and grafana to persist data and settings between runs of the container.
+
+```bash
+mkdir kamon-grafana-service
+cd kamon-grafana-service
+mkdir -p data/whisper
+mkdir -p data/elasticsearch
+mkdir -p data/grafana
+mkdir -p log/graphite
+mkdir -p log/elasticsearch
+chmod -R 777 *
+
+docker run \
+  --detach \
+   --publish=80:80 \
+   --publish=81:81 \
+   --publish=8125:8125/udp \
+   --publish=8126:8126 \
+   --name kamon-grafana-dashboard \
+   --volume=$(pwd)]data\whisper:/opt/graphite/storage/whisper \
+   --volume=$(pwd)]data\elasticsearch:/var/lib/elasticsearch \
+   --volume=$(pwd)]data\grafana:/opt/grafana/data \
+   --volume=$(pwd)]log\graphite:/opt/graphite/storage/log \
+   --volume=$(pwd)]log\elasticsearch:/var/log/elasticsearch \
+   kamon/grafana_graphite
+```
+
+### Now go explore! ###
 
 We hope that you have a lot of fun with this image and that it serves it's
 purpose of making your life easier. This should give you an idea of how the dashboard looks like when receiving data


### PR DESCRIPTION
Resolves [Issue #26](/kamon-io/docker-grafana-graphite/issues/26).

README updated with:
- Up to date link to Docker Hub
- Newer links to Docker networking documentation
- Long-form command line flags in CLI code snippets (with the side effect that the code snippet no longer has a scroll bar..good!)
- Instructions for using the container with host directories mounted into the container as volumes to persist configuration and logs between runs.