### PR TITLE
FIX: Add missing log folder to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ mkdir -p data/whisper
 mkdir -p data/elasticsearch
 mkdir -p data/grafana
 mkdir -p log/graphite
+mkdir -p log/graphite/webapp
 mkdir -p log/elasticsearch
 chmod -R 777 *
 


### PR DESCRIPTION
Without the creation of the log folder, graphite will not start.
I get status code 500 by trying to get http://localhost:8000. With the creation of the correct files, it works.