### PR TITLE
Add APT update before install of first package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ FROM     ubuntu:14.04
 ENV DEBIAN_FRONTEND noninteractive
 
 # Install all prerequisites
+RUN     apt-get -y update
 RUN     apt-get -y install software-properties-common
 RUN     add-apt-repository -y ppa:chris-lea/node.js
 RUN     apt-get -y update


### PR DESCRIPTION
This PR adds a first `apt-get -y update` before the installation of `software-properties-common`.

Without that, the build fails with the following message : `Unable to locate package software-properties-common`