### PR TITLE
Change carbon-cache pidfile dir to /var/run

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -10,7 +10,7 @@ autorestart = true
 
 [program:carbon-cache]
 ;user = www-data
-command = /opt/graphite/bin/carbon-cache.py --debug start
+command = /opt/graphite/bin/carbon-cache.py --pidfile /var/run/carbon-cache-a.pid --debug start
 stdout_logfile = /var/log/supervisor/%(program_name)s.log
 stderr_logfile = /var/log/supervisor/%(program_name)s.log
 autorestart = true


### PR DESCRIPTION
Carbon-cache save pidfile into storage dir /opt/graphite/storage/whisper/. After restart container may not start if user mount this dir for persistance and other process in container has same PID as previous carbon-cache process.

#42 related