### PR TITLE
Note on using `docker-machine ip` on macOS Docker with VirtualBox

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ to know how tha image was built. The repo also has `build` and `start` scripts t
 ### Using the Dashboards ###
 
 Once your container is running all you need to do is:
+
 - open your browser pointing to http://localhost:80 (or another port if you changed it)
+  - Docker with VirtualBox on macOS: use `docker-machine ip` instead of `localhost`
 - login with the default username (admin) and password (admin)
 - open existing dashboard (or create a new one) and select 'Local Graphite' datasource
 - play with the dashboard at your wish...


### PR DESCRIPTION
It's common knowledge that on macOS, one needs to use another IP (normally `192.168.99.100`) instead of localhost, to reach the running Docker.

However, I forgot this. :) Others might as well. So I'm suggesting you to somehow mention it in the README.

Addition of the newline (separate issue) made the markdown show right in my MacDown editor.