### PR TITLE
Add Graphite data port for easy use by `nc`

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ need as a prerequisite is having `docker`, `docker-compose`, and `make` installe
 
 - `80`: the Grafana web interface.
 - `81`: the Graphite web port
+- `2003`: the Graphite data port
 - `8125`: the StatsD port.
 - `8126`: the StatsD administrative port.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - '81:81'
       - '8125:8125/udp'
       - '8126:8126'
+      - '2003:2003'
     volumes:
       - ./data/whisper:/opt/graphite/storage/whisper
       - ./data/grafana:/opt/grafana/data


### PR DESCRIPTION
I had to make changes to push in data via `nc` as described in the Graphite tutorial here.
http://graphite.readthedocs.io/en/latest/feeding-carbon.html