### PR TITLE
Fix Export Wizzy and Grafana Version Update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN     git clone --depth=1 --branch master https://github.com/etsy/statsd.git /
 # Install Grafana
 RUN     mkdir /src/grafana                                                                                           &&\
         mkdir /opt/grafana                                                                                           &&\
-        curl https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-4.6.1.linux-x64.tar.gz \
+        curl https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-4.6.3.linux-x64.tar.gz \
              -o /src/grafana.tar.gz                                                                                  &&\
         tar -xzf /src/grafana.tar.gz -C /opt/grafana --strip-components=1                                            &&\
         rm /src/grafana.tar.gz

--- a/grafana/dashboards/kamon-dashboard.json
+++ b/grafana/dashboards/kamon-dashboard.json
@@ -1081,6 +1081,6 @@
   },
   "refresh": "5s",
   "schemaVersion": 6,
-  "version": 1,
+  "version": 0,
   "links": []
 }


### PR DESCRIPTION
- Fix export when restarting the container
- Grafana 4.6.3